### PR TITLE
Improve indentation to meet hard requirements of different languages.

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -1,8 +1,10 @@
 " Indentation
+filetype indent on
 set expandtab
 set shiftwidth=2
 set tabstop=2
-filetype indent off
+autocmd FileType go set noexpandtab
+autocmd FileType python set shiftwidth=2 expandtab
 
 " Navigation
 set nu


### PR DESCRIPTION
Go (gofmt) requires tabs, whereas Python requires 2 spaces.

Aside from these lang-specific requirements, the remaining vim settings here are just personal preferences.