### PR TITLE
Add max line length hinting for Git commit messages

### DIFF
--- a/.vimrc
+++ b/.vimrc
@@ -5,6 +5,7 @@ set shiftwidth=2
 set tabstop=2
 autocmd FileType go set noexpandtab
 autocmd FileType python set shiftwidth=2 expandtab
+autocmd BufNewFile,BufRead */.git/COMMIT_EDITMSG set textwidth=72 colorcolumn=72
 
 " Navigation
 set nu


### PR DESCRIPTION
Adjusting for max line length manually is quite tiresome. Having automation to help with this is a much less frustrating experience!